### PR TITLE
More closely align cookbook with common tar functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,27 @@ remote_file '/tmp/some_archive.tgz' do
   source 'http://example.com/some_archive.tgz'
 end
 
-# I can also use tarball_x "file" do ...
-tarball '/tmp/some_archive.tgz' do
+# I can use tarball_x "file" do ...
+tarball_x '/tmp/some_archive.tgz' do
   destination '/opt/my_app_path/conf'   # Will be created if missing
   owner 'root'
   group 'root'
   extract_list [ 'properties/*.conf' ]  # Will extract all *.conf files found within the properties dir in the tarball
-  exclude [ 'properties/.gitignore' ]   # Will exclude the .gitfile file that got packaged
   strip_components 1                    # Will strip the first directory (i.e. `properties/`) so that the *.conf files will be placed directly in `/opt/my_app_path/conf`
-  umask 002                             # Will be applied to perms in archive
+  mode '0644'                           # Will apply these permissions to all files extracted (overwrites the permissions within the tarball)
   action :extract
 end
+
+# I can also just use tarball  "file" do ...
+tarball '/tmp/some_other_archive.tar' do
+  destination '/opt/somewhere/else'
+  exclude [ '.gitignore' ]              # Will extract everything, but exclude the .gitfile file that got packaged
+  umask 002                             # Will apply the umask to perms in archive, while retaining their existing permissions within the tarball
+  action :extract
+end
+
 ```
+
 
 It will throw exceptions derived form StandardError in most cases
 (permissions errors, etc.), so you may want to wrap the block in a

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Features
 * Automatically handles gzipped archives
 * Can change mode/ownership
 * Can select specific files only
+* Can exclude files
+* Can emulate `--strip-components`
 * Can handle:
   * regular files
   * directories
@@ -52,11 +54,13 @@ end
 
 # I can also use tarball_x "file" do ...
 tarball '/tmp/some_archive.tgz' do
-  destination '/opt/my_app_path'	# Will be created if missing
+  destination '/opt/my_app_path/conf'   # Will be created if missing
   owner 'root'
   group 'root'
-  extract_list [ '*.conf' ]
-  umask 002				# Will be applied to perms in archive
+  extract_list [ 'properties/*.conf' ]  # Will extract all *.conf files found within the properties dir in the tarball
+  exclude [ 'properties/.gitignore' ]   # Will exclude the .gitfile file that got packaged
+  strip_components 1                    # Will strip the first directory (i.e. `properties/`) so that the *.conf files will be placed directly in `/opt/my_app_path/conf`
+  umask 002                             # Will be applied to perms in archive
   action :extract
 end
 ```

--- a/providers/x.rb
+++ b/providers/x.rb
@@ -28,27 +28,36 @@ rescue StandardError => e
   raise e
 end
 
-def t_stream(f)
-  tgz = Zlib::GzipReader.new(f)
+def t_stream(tarball)
+  tarball_gz = Zlib::GzipReader.new(tarball)
 rescue Zlib::GzipFile::Error
   # Not gzipped
-  f.rewind
-  f
+  tarball.rewind
+  tarball
 else
-  tgz
+  tarball_gz
 end
 
-def mkdestdir(tarball)
-  directory tarball.destination do
+def mkdir(destination, owner = nil, group = nil, mode = nil)
+  return if destination.nil?
+  directory destination do
     action :create
-    owner tarball.owner
-    group tarball.group
-    # We use octal here for UNIX file mode readability, but we could just
-    # as easily have used decimal 511 and gotten the correct behavior
-    mode 0777 & ~tarball.umask.to_i
+    owner owner unless owner.nil?
+    group group unless group.nil?
+    mode mode unless mode.nil?
     recursive true
-    tarball.updated_by_last_action(true)
   end
+end
+
+def mkdestdir(tarball_resource)
+  dest = tarball_resource.destination
+  owner = tarball_resource.owner
+  group = tarball_resource.group
+  # We use octal here for UNIX file mode readability, but we could just
+  # as easily have used decimal 511 and gotten the correct behavior
+  mode = 0777 & ~tarball_resource.umask.to_i
+  mkdir(dest, owner, group, mode)
+  tarball_resource.updated_by_last_action(true)
 end
 
 # Placeholder method in case someone actually needs PAX support
@@ -56,125 +65,127 @@ def pax_handler(pax)
   Chef::Log.debug("PAX: #{pax}") if pax
 end
 
-def t_mkdir(tarball, entry, pax, name = nil)
+def t_mkdir(tarball_resource, entry, pax, name = nil)
   pax_handler(pax)
   if name.nil?
-    dir = ::File.join(tarball.destination, entry.full_name).gsub(%r{/$}, '')
+    dir = ::File.join(tarball_resource.destination, entry.full_name)
+    dir = dir.gsub(%r{/$}, '')
   else
     dir = name
   end
-  directory dir do
-    action :create
-    owner tarball.owner || entry.header.uid
-    group tarball.group || entry.header.gid
-    mode { (fix_mode(entry.header.mode) | 0111) & ~tarball.umask.to_i }
-    recursive true
-  end
+  return if ::File.directory?(dir)
+  owner = tarball_resource.owner || entry.header.uid
+  group = tarball_resource.group || entry.header.gid
+  mode = lambda do
+    (fix_mode(entry.header.mode) | 0111) & ~tarball_resource.umask.to_i
+  end.call
+
+  mkdir(dir, owner, group, mode)
 end
 
-def get_target(tarball, entry, type)
+def get_target(tarball_resource, entry, type)
   if type == :symbolic
     entry.header.linkname
   else
-    ::File.join(tarball.destination, entry.header.linkname)
+    ::File.join(tarball_resource.destination, entry.header.linkname)
   end
 end
 
-def t_link(tarball, entry, type, pax, longname)
+def t_link(tarball_resource, entry, type, pax, longname)
   pax_handler(pax)
-  dir = tarball.destination
-  t_mkdir(tarball, entry, pax, dir) unless ::File.exist?(dir)
-  target = get_target(tarball, entry, type)
+  dir = tarball_resource.destination
+  t_mkdir(tarball_resource, entry, pax, dir)
+  target = get_target(tarball_resource, entry, type)
 
   if type == :hard &&
-     !(::File.exist?(target) || tarball.created_files.include?(target))
+     !(::File.exist?(target) || tarball_resource.created_files.include?(target))
     Chef::Log.debug "Skipping #{entry.full_name}: #{target} not found"
     return
   end
 
   src = ::File.join(dir, longname || entry.full_name)
-  t_mkdir(tarball, entry, pax, ::File.dirname(src)) \
-      unless ::File.directory?(::File.dirname(src))
+  t_mkdir(tarball_resource, entry, pax, ::File.dirname(src))
   link src do
     to target
-    owner tarball.owner || entry.header.uid
+    owner tarball_resource.owner || entry.header.uid
     link_type type
     action :create
   end
 end
 
-def t_file(tarball, entry, pax, longname)
+def t_file(tarball_resource, entry, pax, longname)
   pax_handler(pax)
   file_name = longname || entry.full_name
   Chef::Log.info "Creating file #{file_name}"
-  fqpn = ::File.join(tarball.destination, file_name)
-  t_mkdir(tarball, entry, pax, ::File.dirname(fqpn)) \
-      unless ::File.directory?(::File.dirname(fqpn))
+  fqpn = ::File.join(tarball_resource.destination, file_name)
+  t_mkdir(tarball_resource, entry, pax, ::File.dirname(fqpn))
   file fqpn do
     action :create
-    owner tarball.owner || entry.header.uid
-    group tarball.group || entry.header.gid
-    mode fix_mode(entry.header.mode) & ~tarball.umask.to_i
+    owner tarball_resource.owner || entry.header.uid
+    group tarball_resource.group || entry.header.gid
+    mode fix_mode(entry.header.mode) & ~tarball_resource.umask.to_i
     sensitive true
     content entry.read
   end
-  tarball.created_files << fqpn
+  tarball_resource.created_files << fqpn
 end
 
-def on_list?(name, tarball)
-  Array(tarball.extract_list).each do |r|
-    return true if ::File.fnmatch?(r, name)
+def on_list?(filename, tarball_resource)
+  Array(tarball_resource.extract_list).each do |r|
+    return true if ::File.fnmatch?(r, filename)
   end
   false
 end
 
-def wanted?(name, tarball, type)
-  if ::File.exist?(::File.join(tarball.destination, name)) &&
-     tarball.overwrite == false
+def wanted?(filename, tarball_resource, type)
+  if ::File.exist?(::File.join(tarball_resource.destination, filename)) &&
+     tarball_resource.overwrite == false
     false
   elsif %w(2 5 L).include?(type)
     true
-  elsif tarball.extract_list
-    on_list?(name, tarball)
+  elsif tarball_resource.extract_list
+    on_list?(filename, tarball_resource)
   else
     true
   end
 end
 
-def t_extraction(tar, tarball)
+def t_extraction(tarball, tarball_resource)
   # pax and longname track extended types that span more than one tar entry
   pax = nil
   longname = nil
-  Gem::Package::TarReader.new(tar).each do |ent|
-    next unless wanted?(ent.full_name, tarball, ent.header.typeflag)
-    Chef::Log.info "Next tar entry: #{ent.full_name}"
-    case ent.header.typeflag
+  Gem::Package::TarReader.new(tarball).each do |entry|
+    unless wanted?(entry.full_name, tarball_resource, entry.header.typeflag)
+      next
+    end
+    Chef::Log.info "Next tar entry: #{entry.full_name}"
+    case entry.header.typeflag
     when '1'
-      t_link(tarball, ent, :hard, pax, longname)
+      t_link(tarball_resource, entry, :hard, pax, longname)
       pax = nil
       longname = nil
     when '2'
-      t_link(tarball, ent, :symbolic, pax, longname)
+      t_link(tarball_resource, entry, :symbolic, pax, longname)
       pax = nil
       longname = nil
     when '5'
-      t_mkdir(tarball, ent, pax)
+      t_mkdir(tarball_resource, entry, pax)
       pax = nil
       longname = nil
     when '3', '4', '6', '7'
-      Chef::Log.debug "Can't handle type for #{ent.full_name}: skipping"
+      Chef::Log.debug "Can't handle type for #{entry.full_name}: skipping"
       pax = nil
       longname = nil
     when 'x', 'g'
       Chef::Log.debug 'PaxHeader'
-      pax = ent
+      pax = entry
       longname = nil
     when 'L', 'K'
-      longname = ent.read.strip
+      longname = entry.read.strip
       Chef::Log.debug "Using LONG(NAME|LINK) #{longname}"
       pax = nil
     else
-      t_file(tarball, ent, pax, longname)
+      t_file(tarball_resource, entry, pax, longname)
       pax = nil
       longname = nil
     end
@@ -189,11 +200,11 @@ end
 provides :tarball if self.respond_to?('provides')
 
 action :extract do
-  tarball = new_resource
-  Chef::Log.info "TARFILE: #{tarball.source || tarball.name}"
-  tar = t_open(tarball.source || tarball.name)
-  tar = t_stream(tar)
-  mkdestdir(tarball)
-  t_extraction(tar, tarball)
+  tarball_resource = new_resource
+  Chef::Log.info "TARFILE: #{tarball_resource.source || tarball_resource.name}"
+  tarball = t_open(tarball_resource.source || tarball_resource.name)
+  tarball = t_stream(tarball)
+  mkdestdir(tarball_resource)
+  t_extraction(tarball, tarball_resource)
   new_resource.updated_by_last_action(true)
 end

--- a/providers/x.rb
+++ b/providers/x.rb
@@ -77,7 +77,7 @@ def t_mkdir(tarball_resource, entry, pax, name = nil)
   return if dir.empty? || ::File.directory?(dir)
   owner = tarball_resource.owner || entry.header.uid
   group = tarball_resource.group || entry.header.gid
-  mode = lambda do
+  mode = tarball_resource.mode || lambda do
     (fix_mode(entry.header.mode) | 0111) & ~tarball_resource.umask.to_i
   end.call
 
@@ -144,7 +144,8 @@ def t_file(tarball_resource, entry, pax, longname)
     action :create
     owner tarball_resource.owner || entry.header.uid
     group tarball_resource.group || entry.header.gid
-    mode fix_mode(entry.header.mode) & ~tarball_resource.umask.to_i
+    mode tarball_resource.mode ||
+      fix_mode(entry.header.mode) & ~tarball_resource.umask.to_i
     sensitive true
     content entry.read
   end

--- a/providers/x.rb
+++ b/providers/x.rb
@@ -123,7 +123,7 @@ end
 
 def on_list?(name, tarball)
   Array(tarball.extract_list).each do |r|
-    return true if ::File.basename(name).match(Regexp.quote(r))
+    return true if ::File.fnmatch?(r, name)
   end
   false
 end

--- a/providers/x.rb
+++ b/providers/x.rb
@@ -99,7 +99,7 @@ def get_tar_entry_path(tarball_resource, full_path)
             .each_filename
             .drop(tarball_resource.strip_components)
     if paths.empty?
-      full_path = ""
+      full_path = ''
     else
       full_path = ::File.join(paths)
     end

--- a/recipes/test.rb
+++ b/recipes/test.rb
@@ -13,12 +13,14 @@
 
 include_recipe 'tarball::default'
 
-cookbook_file 'testing.tgz' do
-  path '/tmp/testing.tgz'
+file = 'testing.tgz'
+
+cookbook_file file do
+  path "/tmp/#{file}"
   action :create
 end
 
-tarball '/tmp/testing.tgz' do
+tarball "/tmp/#{file}" do
   destination '/tmp/testing1'
   owner 'root'
   group 'root'
@@ -26,7 +28,7 @@ tarball '/tmp/testing.tgz' do
   action :extract
 end
 
-file '/tmp/testing.tgz' do
+file "/tmp/#{file}" do
   action :delete
 end
 
@@ -44,6 +46,20 @@ tarball_x 'test2' do
   group 'sys'
   extract_list ['**/1', '**/*_to_*']
   action :extract
+end
+
+tarball_x 'test3 excluding' do
+  source lazy { "/tmp/#{file}" }
+  destination '/tmp/testing3'
+  owner 'root'
+  group 'root'
+  exclude ['**/1', 'testing/a/2', 'testing/**/3', '**/q/**']
+end
+
+tarball_x 'test4 strip_components' do
+  source "/tmp/#{file}"
+  destination '/tmp/testing4'
+  strip_components 2
 end
 
 file 'testing.tar' do

--- a/recipes/test.rb
+++ b/recipes/test.rb
@@ -42,7 +42,7 @@ tarball_x 'test2' do
   destination '/tmp/testing2'
   owner 'root'
   group 'sys'
-  extract_list ['1', '/.*_to_.*/']
+  extract_list ['**/1', '**/*_to_*']
   action :extract
 end
 

--- a/recipes/test.rb
+++ b/recipes/test.rb
@@ -11,8 +11,6 @@
 # implied.  See the License for the specific language governing
 # permissions and limitations under the License.
 
-include_recipe 'tarball::default'
-
 file = 'testing.tgz'
 
 cookbook_file file do
@@ -44,6 +42,7 @@ tarball_x 'test2' do
   destination '/tmp/testing2'
   owner 'root'
   group 'sys'
+  mode '0755'
   extract_list ['**/1', '**/*_to_*']
   action :extract
 end

--- a/resources/x.rb
+++ b/resources/x.rb
@@ -29,6 +29,8 @@ attribute :owner, kind_of: String
 attribute :group, kind_of: String
 attribute :umask, kind_of: [String, Integer], default: 022
 attribute :overwrite, kind_of: [TrueClass, FalseClass], default: true
+attribute :exclude, kind_of: [Array, String]
+attribute :strip_components, kind_of: [Integer]
 
 # This attribute is *not* meant to be passed as in the tarball_x block
 attribute :created_files, kind_of: Array, default: []

--- a/resources/x.rb
+++ b/resources/x.rb
@@ -27,6 +27,7 @@ attribute :destination, kind_of: String, required: true
 attribute :extract_list, kind_of: [Array, String]
 attribute :owner, kind_of: String
 attribute :group, kind_of: String
+attribute :mode, kind_of: [String, Integer]
 attribute :umask, kind_of: [String, Integer], default: 022
 attribute :overwrite, kind_of: [TrueClass, FalseClass], default: true
 attribute :exclude, kind_of: [Array, String]

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -280,10 +280,11 @@ describe 'tarball::test' do
     end
 
     {
-      "b/hardlink_to_1" => "b/1"
+      'b/hardlink_to_1' => 'b/1'
     }.each_pair do |l, t|
-      expect(chef_run).to create_link("#{dir}/#{l}").with_link_type(:hard).with_to("#{dir}/#{t}")
+      expect(chef_run).to create_link("#{dir}/#{l}")
+        .with_link_type(:hard)
+        .with_to("#{dir}/#{t}")
     end
-
   end
 end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -125,7 +125,7 @@ describe 'tarball::test' do
   it 'creates another set of extracted files as expected' do
     %w( testing/a/b/1 ).each do |f|
       expect(chef_run).to create_file("/tmp/testing2/#{f}")
-      expect(chef_run).to create_file("/tmp/testing2/#{f}").with(mode: 0644)
+      expect(chef_run).to create_file("/tmp/testing2/#{f}").with(mode: '0755')
       expect(chef_run).to create_file("/tmp/testing2/#{f}").with(owner: 'root')
       expect(chef_run).to create_file("/tmp/testing2/#{f}").with(group: 'sys')
     end

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -32,6 +32,8 @@ describe 'tarball::test' do
 
   it 'calls tarball_x' do
     expect(chef_run).to extract_tarball_x('test2')
+    expect(chef_run).to extract_tarball_x('test3 excluding')
+    expect(chef_run).to extract_tarball_x('test4 strip_components')
   end
 
   it 'removes /tmp/testing.tgz' do
@@ -71,6 +73,8 @@ describe 'tarball::test' do
   it 'creates extraction dirs' do
     expect(chef_run).to create_directory('/tmp/testing1')
     expect(chef_run).to create_directory('/tmp/testing2')
+    expect(chef_run).to create_directory('/tmp/testing3')
+    expect(chef_run).to create_directory('/tmp/testing4')
   end
 
   it 'creates extracted files as expected' do
@@ -156,5 +160,130 @@ describe 'tarball::test' do
     ).each do |l|
       expect(chef_run).to create_link(l).with_link_type(:hard)
     end
+  end
+
+  it 'excludes some files' do
+    exclude_dir = '/tmp/testing3'
+    %w(
+      testing
+      testing/a
+      testing/a/b
+      testing/a/b/c
+      testing/a/b/d
+      testing/e
+      testing/e/f
+      testing/e/g
+      testing/e/h
+      testing/e/h/i
+      testing/e/h/i/j
+      testing/e/h/i/j/k
+      testing/e/h/i/j/k/l
+      testing/e/h/i/j/k/l/m
+      testing/e/h/i/j/k/l/m/n
+      testing/e/h/i/j/k/l/m/n/o
+      testing/e/h/i/j/k/l/m/n/o/p
+    ).each do |d|
+      expect(chef_run).to create_directory("#{exclude_dir}/#{d}")
+    end
+
+    %w(
+      testing/a/2
+      testing/e/h/3
+      testing/e/h/i/j/k/l/m/n/o/p/q
+      testing/e/h/i/j/k/l/m/n/o/p/q/r
+      testing/e/h/i/j/k/l/m/n/o/p/q/r/3
+    ).each do |d|
+      expect(chef_run).to_not create_directory("#{exclude_dir}/#{d}")
+    end
+
+    %w(
+      testing/e/h/4
+      testing/e/h/5
+      testing/e/h/6
+    ).each do |f|
+      expect(chef_run).to create_file("#{exclude_dir}/#{f}")
+    end
+
+    %w(
+      testing/a/2
+      testing/a/b/1
+      testing/e/h/3
+      testing/e/h/i/j/k/l/m/n/o/p/q/r/3
+    ).each do |f|
+      expect(chef_run).to_not create_file("#{exclude_dir}/#{f}")
+    end
+
+    %w(
+      testing/a/symlink_to_2
+      testing/a/symlink_to_3
+    ).each do |l|
+      expect(chef_run).to create_link("#{exclude_dir}/#{l}")
+    end
+
+    # Hardlink does not get created since the testing/a/b/1 file it points
+    # to is not created
+    %w(
+      testing/a/b/hardlink_to_1
+    ).each do |l|
+      expect(chef_run).to_not create_link("#{exclude_dir}/#{l}")
+    end
+  end
+
+  it 'strips components' do
+    dir = '/tmp/testing4'
+    %w(
+      b
+      b/c
+      b/d
+      f
+      g
+      h
+      h/i
+      h/i/j
+      h/i/j/k
+      h/i/j/k/l
+      h/i/j/k/l/m
+      h/i/j/k/l/m/n
+      h/i/j/k/l/m/n/o
+      h/i/j/k/l/m/n/o/p
+      h/i/j/k/l/m/n/o/p/q
+      h/i/j/k/l/m/n/o/p/q/r
+    ).each do |d|
+      expect(chef_run).to create_directory("#{dir}/#{d}")
+    end
+
+    %w(
+      testing
+      testing/a
+      testing/e
+    ).each do |d|
+      expect(chef_run).to_not create_directory("#{dir}/#{d}")
+    end
+
+    %w(
+      2
+      b/1
+      h/3
+      h/i/j/k/l/m/n/o/p/q/r/3
+      h/4
+      h/5
+      h/6
+    ).each do |f|
+      expect(chef_run).to create_file("#{dir}/#{f}")
+    end
+
+    %w(
+      symlink_to_2
+      symlink_to_3
+    ).each do |l|
+      expect(chef_run).to create_link("#{dir}/#{l}").with_link_type(:symbolic)
+    end
+
+    {
+      "b/hardlink_to_1" => "b/1"
+    }.each_pair do |l, t|
+      expect(chef_run).to create_link("#{dir}/#{l}").with_link_type(:hard).with_to("#{dir}/#{t}")
+    end
+
   end
 end


### PR DESCRIPTION
This will better enable users to use the cookbook, as this more closely aligns with how `tar` parameters are actually interacted with. 
-  Allows users to specify specific shell globs to use in the extract_list
-  Allows users to specify files to exclude (via shell globs again)
-  Allows users to specify a level to strip components (simulating the `--strip-components` parameter).
-  Allows users to specify the mode to overwrite file permissions

I also added tests for the new features.
